### PR TITLE
MARP-191: Failed to retrieve signingurl by email

### DIFF
--- a/adobe-acrobat-sign-connector-demo/src_hd/com/axonivy/connector/adobe/acrobat/sign/connector/demo/Demo/DemoProcess.p.json
+++ b/adobe-acrobat-sign-connector-demo/src_hd/com/axonivy/connector/adobe/acrobat/sign/connector/demo/Demo/DemoProcess.p.json
@@ -143,7 +143,7 @@
           }
         },
         "output" : {
-          "code" : "in.signingURI = com.axonivy.connector.adobe.acrobat.sign.connector.util.AdobeSignUtils.getSigningURIByEmail(in.signer1, result.signingURIs);"
+          "code" : "in.signingURI = com.axonivy.connector.adobe.acrobat.sign.connector.util.AdobeSignUtils.getESignUrlByEmail(in.signer1, result.signingURIs);"
         }
       },
       "visual" : {
@@ -348,7 +348,7 @@
           }
         },
         "output" : {
-          "code" : "in.signingURI = com.axonivy.connector.adobe.acrobat.sign.connector.util.AdobeSignUtils.getSigningURIByEmail(in.signer2, result.signingURIs);"
+          "code" : "in.signingURI = com.axonivy.connector.adobe.acrobat.sign.connector.util.AdobeSignUtils.getESignUrlByEmail(in.signer2, result.signingURIs);"
         }
       },
       "visual" : {

--- a/adobe-acrobat-sign-connector-demo/src_hd/com/axonivy/connector/adobe/acrobat/sign/connector/demo/Demo/DemoProcess.p.json
+++ b/adobe-acrobat-sign-connector-demo/src_hd/com/axonivy/connector/adobe/acrobat/sign/connector/demo/Demo/DemoProcess.p.json
@@ -143,18 +143,7 @@
           }
         },
         "output" : {
-          "code" : [
-            "import api.rest.v6.client.SigningUrlResponseSigningUrls;",
-            "import api.rest.v6.client.SigningUrlResponseSigningUrlSetInfos;",
-            "",
-            "for(SigningUrlResponseSigningUrlSetInfos signingInfos : result.signingURIs) {",
-            "  for(SigningUrlResponseSigningUrls signingUrls : signingInfos.getSigningUrls()) {",
-            "    if(signingUrls.email.equals(in.signer1)) {",
-            "      in.signingURI = signingUrls.esignUrl;",
-            "    }",
-            "  }",
-            "}"
-          ]
+          "code" : "in.signingURI = com.axonivy.connector.adobe.acrobat.sign.connector.util.AdobeSignUtils.getSigningURIByEmail(in.signer1, result.signingURIs);"
         }
       },
       "visual" : {
@@ -359,18 +348,7 @@
           }
         },
         "output" : {
-          "code" : [
-            "import api.rest.v6.client.SigningUrlResponseSigningUrls;",
-            "import api.rest.v6.client.SigningUrlResponseSigningUrlSetInfos;",
-            "",
-            "for(SigningUrlResponseSigningUrlSetInfos signingInfos : result.signingURIs) {",
-            "  for(SigningUrlResponseSigningUrls signingUrls : signingInfos.getSigningUrls()) {",
-            "    if(signingUrls.email.equals(in.signer2)) {",
-            "      in.signingURI = signingUrls.esignUrl;",
-            "    }",
-            "  }",
-            "}"
-          ]
+          "code" : "in.signingURI = com.axonivy.connector.adobe.acrobat.sign.connector.util.AdobeSignUtils.getSigningURIByEmail(in.signer2, result.signingURIs);"
         }
       },
       "visual" : {

--- a/adobe-acrobat-sign-connector/src/com/axonivy/connector/adobe/acrobat/sign/connector/util/AdobeSignUtils.java
+++ b/adobe-acrobat-sign-connector/src/com/axonivy/connector/adobe/acrobat/sign/connector/util/AdobeSignUtils.java
@@ -1,0 +1,50 @@
+package com.axonivy.connector.adobe.acrobat.sign.connector.util;
+
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+import java.util.List;
+
+import org.apache.commons.collections4.CollectionUtils;
+
+import api.rest.v6.client.SigningUrlResponseSigningUrlSetInfos;
+
+public class AdobeSignUtils {
+
+	/**
+	 * Retrieves the e-signature URL associated with a specific signer's email.
+	 *
+	 * This method iterates through a list of signing URL information, checking each
+	 * set for a match with the provided email. If a match is found, the
+	 * corresponding e-signature URL is returned. If no match is found, or if the
+	 * input parameters are invalid (null or empty), an empty string is returned.
+	 *
+	 * @param signerEmail                The email address of the signer whose
+	 *                                   e-sign URL is being requested. This must
+	 *                                   not be null or blank.
+	 * @param responseSigningUrlSetInfos A list of
+	 *                                   {@link SigningUrlResponseSigningUrlSetInfos}
+	 *                                   which contains the signing URLs and
+	 *                                   associated signer emails. This list must
+	 *                                   not be empty.
+	 * @return The e-sign URL as a String. Returns an empty string if no match is
+	 *         found or if input parameters are invalid.
+	 */
+	public static String getESignUrlByEmail(String signerEmail,
+			List<SigningUrlResponseSigningUrlSetInfos> responseSigningUrlSetInfos) {
+		var signingURI = EMPTY;
+		if (isBlank(signerEmail) || CollectionUtils.isEmpty(responseSigningUrlSetInfos)) {
+			return signingURI;
+		}
+		for (var signingInfos : responseSigningUrlSetInfos) {
+			for (var signingUrls : CollectionUtils.emptyIfNull(signingInfos.getSigningUrls())) {
+				if (equalsIgnoreCase(signingUrls.getEmail(), signerEmail)) {
+					signingURI = signingUrls.getEsignUrl();
+				}
+			}
+		}
+		return signingURI;
+	}
+
+}


### PR DESCRIPTION
- Introduced new util to adobe-sign to get the signing URL by email
- Update the demo project to use it